### PR TITLE
Refactor and prepare plugin for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# discourse-sign-in-with-apple
-Login to Discourse with your Apple ID
+# discourse-apple-auth
+Login to Discourse using 'Sign in with Apple'
 
-**NOT** currently Production-worthy due to upstream issues discussed [here](https://meta.discourse.org/t/sign-in-with-apple/122790/22?u=merefield) and [here](https://meta.discourse.org/t/sign-in-with-apple/122790/35?u=merefield)
+For information and support, see https://meta.discourse.org/t/sign-in-with-apple-plugin/171485
 
 

--- a/assets/stylesheets/apple-auth.scss
+++ b/assets/stylesheets/apple-auth.scss
@@ -1,0 +1,4 @@
+.btn-social.apple {
+  background: #000;
+  color: #fff;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3,5 +3,5 @@ en:
     login:
       apple:
         name: "Apple"
-        title: "Sign-in with Apple"
-        message: "Authenticating with Apple (make sure pop up blockers are not enabled)"
+        title: "with Apple"
+        message: "Authenticating with Apple"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,8 +1,8 @@
 en:
   site_settings:
-    sign_in_with_apple_enabled: 'Allow users to sign in with their Apple ID?'
-    apple_client_id: "The Apple 'Service Identifier' from the developer console. Normally a reverse-domain name style string (e.g. com.example.auth)"
-    apple_team_id: 'Apple Team ID (10 characters)'
-    apple_key_id: 'Apple Key ID (10 characters)'
-    apple_pem: 'Apple Pem File Content. Include the BEGIN and END lines'
-    apple_verification_txt: "Paste the content of the web domain verification file here. It will be served at /.well-known/apple-developer-domain-association.txt"
+    sign_in_with_apple_enabled: 'Enable sign in with Apple?'
+    apple_client_id: "(Sign in with Apple) The Apple 'Service Identifier' from the developer console. Normally a reverse-domain name style string (e.g. com.example.auth) (Sign in with Apple)"
+    apple_team_id: '(Sign in with Apple) Apple Team ID (10 characters)'
+    apple_key_id: '(Sign in with Apple) Apple Key ID (10 characters)'
+    apple_pem: '(Sign in with Apple) Apple Pem File Content. Include the BEGIN and END lines'
+    apple_verification_txt: "(Sign in with Apple) Paste the content of the web domain verification file here. It will be served at /.well-known/apple-developer-domain-association.txt"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,18 +1,9 @@
 plugins:
-  sign_in_with_apple_enabled:
-    client: true
-    default: false
-  apple_client_id:
-    client: false
-    default: ''
-  apple_team_id:
-    client: false
-    default: ''
-  apple_key_id:
-    client: false
-    default: ''
+  sign_in_with_apple_enabled: false
+  apple_client_id: ''
+  apple_team_id: ''
+  apple_key_id: ''
   apple_pem:
-    client: false
     default: ''
     textarea: true
   apple_verification_txt:

--- a/lib/omniauth_apple.rb
+++ b/lib/omniauth_apple.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'omniauth-oauth2'
+
+# There is an omniauth-apple gem which we could use here
+# But it has many more features than we need, and more surface area for bugs/exploits
+#
+# This implementation also has a workaround which redirects
+# Apple's POST callbacks to GET requests, so that the browser sends SameSite=Lax
+# cookies in the request.
+#
+# We may want to switch to the gem in future, especially if Apple change
+# the implementation
+
+module OmniAuth
+  module Strategies
+    class Apple < OmniAuth::Strategies::OAuth2
+      option :name, 'apple'
+
+      option :client_options,
+             site: 'https://appleid.apple.com',
+             authorize_url: '/auth/authorize',
+             token_url: '/auth/token'
+
+      option :authorize_params,
+             response_mode: 'form_post',
+             scope: 'email name'
+
+      uid { id_token_info['sub'] }
+
+      info do
+        {}.tap do |h|
+          h[:email] = id_token_info['email'] if id_token_info['email']
+          h[:first_name] = unsafe_user_info.dig('name', 'firstName')
+          h[:last_name] = unsafe_user_info.dig('name', 'lastName')
+          if h[:first_name] && h[:last_name]
+            h[:name] = "#{h[:first_name]} #{h[:last_name]}"
+          end
+        end
+      end
+
+      extra do
+        {
+          raw_info: {
+            id_token_info: id_token_info,
+            id_token: access_token["id_token"]
+          }
+        }
+      end
+
+      def client
+        ensure_client_secret
+        super
+      end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
+      def callback_phase
+        if request.request_method.downcase.to_sym == :post
+          url = "#{callback_url}"
+          if (code = request.params['code']) && (state = request.params['state'])
+            url += "?code=#{CGI::escape(code)}"
+            url += "&state=#{CGI::escape(state)}"
+            url += "&user=#{CGI::escape(request.params['user'])}" if request.params['user']
+          end
+          session.options[:drop] = true # Do not set a session cookie on this response
+          return redirect url
+        end
+        super
+      end
+
+      private
+
+      def id_token_info
+        # Verify the claims in the JWT
+        # The signature does not need to be verified because the
+        # token was acquired via a direct server-server connection to the issuer
+        @id_token_info ||= begin
+          decoded, _h = ::JWT.decode(access_token['id_token'], nil, false)
+
+          ::JWT::Verify.verify_claims(decoded,
+            verify_iss: true,
+            iss: 'https://appleid.apple.com',
+            verify_aud: true,
+            aud: options.client_id,
+            verify_not_before: true,
+            verify_expiration: true,
+          )
+
+          decoded
+        end
+      end
+
+      def unsafe_user_info
+        @unsafe_user_info ||= begin
+          JSON.parse(request.params['user'] || '')
+        rescue JSON::ParserError
+          {}
+        end
+      end
+
+      def ensure_client_secret
+        options[:client_secret] ||= client_secret
+      end
+
+      def client_secret
+        payload = {
+          iss: options.team_id,
+          aud: 'https://appleid.apple.com',
+          sub: options.client_id,
+          iat: Time.now.to_i,
+          exp: Time.now.to_i + 60
+        }
+        headers = { kid: options.key_id }
+
+        ::JWT.encode(payload, ::OpenSSL::PKey::EC.new(options.pem), 'ES256', headers)
+      end
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 # name: discourse-apple-auth
-# about: Enable Login via Apple services aka "Sign-in with Apple"
-# version: 0.1
-# authors: Robert Barrow
-# url: https://github.com/merefield/discourse-apple-auth
+# about: Enable login via "Sign-in with Apple"
+# version: 1.0
+# authors: Robert Barrow, David Taylor
+# url: https://github.com/discourse/discourse-auth-apple
 
-gem 'omniauth-apple', '1.0.0'
+require_relative "lib/omniauth_apple"
 
-require 'omniauth-apple'
-
-register_svg_icon "fab-apple" if respond_to?(:register_svg_icon)
+register_svg_icon "fab-apple"
 
 enabled_site_setting :sign_in_with_apple_enabled
+
+register_asset "stylesheets/apple-auth.scss"
 
 after_initialize do
   class ::AppleVerificationController < ::ApplicationController
@@ -30,7 +30,6 @@ after_initialize do
 end
 
 class AppleAuthenticator < ::Auth::ManagedAuthenticator
-
   def name
     'apple'
   end
@@ -47,22 +46,9 @@ class AppleAuthenticator < ::Auth::ManagedAuthenticator
             strategy.options[:team_id] = SiteSetting.apple_team_id
             strategy.options[:key_id] = SiteSetting.apple_key_id
             strategy.options[:pem] = SiteSetting.apple_pem
-            strategy.options[:info_fields] = 'email,name'
-          },
-          scope: 'email name'
+          }
   end
 end
 
 auth_provider icon: 'fab-apple',
-              frame_width: 920,
-              frame_height: 800,
-              authenticator: AppleAuthenticator.new,
-              full_screen_login: true
-
-register_css <<CSS
-
-.btn-social.apple {
-  background: #000000;
-}
-
-CSS
+              authenticator: AppleAuthenticator.new

--- a/spec/requests/auth_apple_spec.rb
+++ b/spec/requests/auth_apple_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/omniauth_apple'
+require 'rails_helper'
+
+pem = ::OpenSSL::PKey::EC.generate('prime256v1').to_pem
+
+describe "sign in with apple" do
+  before do
+    SiteSetting.sign_in_with_apple_enabled = true
+    SiteSetting.apple_client_id = "myclientid"
+    SiteSetting.apple_team_id = "myteamid"
+    SiteSetting.apple_key_id = "mykeyid"
+    SiteSetting.apple_pem = pem
+  end
+
+  let(:user_payload) do
+    {
+      email: "maybe-spoofed-email@example.com",
+      name: {
+        firstName: "Disco",
+        lastName: "Bot"
+      }
+    }
+  end
+
+  it "starts the flow correctly" do
+    post "/auth/apple"
+    expect(response.status).to eq(302)
+    expect(response.location).to start_with("https://appleid.apple.com/auth/authorize")
+    expect(response.location).to include("client_id=myclientid")
+  end
+
+  describe "POST callback" do
+    # Apple send the callback as a POST, which is incompatible
+    # with samesite=lax cookies
+
+    it "redirects to GET" do
+      post "/auth/apple/callback", params: {
+        code: "supersecretcode",
+        state: "uniquestate",
+      }
+      expect(response.status).to eq(302)
+      expect(response.location).to eq("http://test.localhost/auth/apple/callback?code=supersecretcode&state=uniquestate")
+    end
+
+    it "includes the user data if present" do
+      post "/auth/apple/callback", params: {
+        code: "supersecretcode",
+        state: "uniquestate",
+        user: user_payload.to_json
+      }
+      expect(response.status).to eq(302)
+      expect(response.location).to include("user=%7B")
+    end
+
+    it "does not set any cookies" do
+      # This cross-site request has no cookies (because they're samesite=lax)
+      # By default the session middleware will try and start a new session
+      # which would break the existing session
+      post "/auth/apple/callback"
+      expect(response.status).to eq(302)
+      expect(response.headers["Set-Cookie"]).to eq(nil)
+    end
+  end
+
+  describe "GET callback" do
+    before do
+      post "/auth/apple"
+      expect(response.status).to eq(302)
+
+      # Mock the apple server
+      stub_request(:post, "https://appleid.apple.com/auth/token").to_return do |request|
+        # https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens
+        # https://developer.apple.com/documentation/sign_in_with_apple/tokenresponse
+
+        params = Rack::Utils.parse_nested_query(request.body)
+
+        expect(params["client_id"]).to eq("myclientid")
+        expect(params["code"]).to eq("supersecretcode")
+
+        decoded, header = JWT.decode(params["client_secret"], nil, false)
+        expect(decoded["iss"]).to eq("myteamid")
+        expect(decoded["sub"]).to eq("myclientid")
+        expect(header["kid"]).to eq("mykeyid")
+
+        {
+          status: 200,
+          body: {
+            access_token: "wedontusethis",
+            expires_in: 10,
+            id_token: ::JWT.encode({
+              iss: "https://appleid.apple.com",
+              aud: "myclientid",
+              sub: "unique-user-id",
+              email: "verified-email@example.com",
+            }, nil, 'none'),
+            refresh_token: "wedontusethis",
+            token_type: "bearer"
+          }.to_json,
+          headers: {
+            "Content-Type" => "application/json"
+          }
+        }
+      end
+    end
+
+    it "works" do
+      # Like an OAuth2 callback, but with some apple-specific stuff per
+      # https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_js/incorporating_sign_in_with_apple_into_other_platforms
+      get "/auth/apple/callback", params: {
+        code: "supersecretcode",
+        state: session['omniauth.state'],
+        id_token: JWT.encode({ email: "wedontusethis" }, nil, 'none'),
+        user: user_payload.to_json
+      }
+      expect(response.status).to eq(302)
+      expect(response.location).to eq("http://test.localhost/")
+
+      result = Auth::Result.from_session_data(session[:authentication], user: nil)
+      expect(result.email).to eq("verified-email@example.com")
+      expect(result.name).to eq("Disco Bot")
+      expect(result.extra_data[:uid]).to eq("unique-user-id")
+    end
+  end
+
+end


### PR DESCRIPTION
- Remove omniauth-apple gem, use an embedded omniauth strategy instead
- Add a redirect to make POST callbacks work with SameSite=Lax cookies
- Add integration tests
- Remove use of some deprecated plugin APIs